### PR TITLE
feat(preview): add u and d keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ The following keybinds are active when preview window is focused:
 
 | key ||
 |-|-|
-| k | scroll up         |
-| j | scroll down       |
-| g | scroll to top     |
-| G | scroll to bottom  |
+| k | scroll up               |
+| j | scroll down             |
+| u | scroll up half a page   |
+| d | scroll down half a page |
+| g | scroll to top           |
+| G | scroll to bottom        |
 
 ### :mag: Preview window
 

--- a/client/src/script.ts
+++ b/client/src/script.ts
@@ -73,6 +73,12 @@ function setKeybinds() {
       case 'k':
         window.scrollBy({ top: -50 });
         break;
+      case 'd':
+        window.scrollBy({ top: window.innerHeight / 2 });
+        break;
+      case 'u':
+        window.scrollBy({ top: -window.innerHeight / 2 });
+        break;
       case 'g':
         window.scrollTo({ top: 0 });
         break;


### PR DESCRIPTION
Equivalent to vim's ctrl-u and ctrl-d normal mode keybinds which scroll the buffer by half a screen up and half a screen down respectively