### PR TITLE
feat: Render tex math notation

### DIFF
--- a/app/src/markdownit.ts
+++ b/app/src/markdownit.ts
@@ -8,6 +8,9 @@ import { default as MarkdownItEmoji } from 'https://esm.sh/markdown-it-emoji@2.0
 import { default as MarkdownItFootnote } from 'https://esm.sh/markdown-it-footnote@3.0.3?no-dts';
 // @deno-types="./markdownit_plugin.d.ts"
 import { default as MarkdownItTaskLists } from 'https://esm.sh/markdown-it-task-lists@2.1.1?no-dts';
+// @deno-types="./markdownit_plugin.d.ts"
+import { default as MarkdownItTexmath } from 'https://esm.sh/markdown-it-texmath@1.0.0?no-dts';
+import Katex from 'https://esm.sh/katex@0.16.3?no-dts';
 
 const __args = parse(Deno.args);
 
@@ -27,7 +30,12 @@ const md = new MarkdownIt('default', {
   }),
 }).use(MarkdownItEmoji)
   .use(MarkdownItFootnote)
-  .use(MarkdownItTaskLists, { enabled: false, label: true });
+  .use(MarkdownItTaskLists, { enabled: false, label: true })
+  .use(MarkdownItTexmath, {
+    engine: Katex,
+    delimiters: ['dollars', 'gitlab'],
+    katexOptions: { macros: { '\\R': '\\mathbb{R}' } },
+  });
 
 md.renderer.rules.link_open = (tokens, idx, options) => {
   const token = tokens[idx];

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="github-markdown.min.css" rel="stylesheet">
   <link href="style.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css" rel="stylesheet">
 </head>
 
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -6,8 +6,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="github-markdown.min.css" rel="stylesheet">
-  <link href="style.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css" rel="stylesheet">
+  <link href="style.css" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
First, thank you for the great plugin.

## Render math notation with Katex

I enabled the following delimiters:
- Standard notation:
  - `$...$` for inline math
  - `$$...$$` for blocks
- Gitlab notation (because math blocks are now also rendered on Github):
  - `` $`...`$ `` for inline math
  - `` ```math...``` `` for blocks 

**Example**:
![tex_math](https://user-images.githubusercontent.com/50531499/199436746-a241d295-1142-4dcb-a2b5-1adccbb96781.png)