### PR TITLE
feat: Add markdown it plugin to render textual umls

### DIFF
--- a/app/src/markdownit.ts
+++ b/app/src/markdownit.ts
@@ -8,6 +8,8 @@ import { default as MarkdownItEmoji } from 'https://esm.sh/markdown-it-emoji@2.0
 import { default as MarkdownItFootnote } from 'https://esm.sh/markdown-it-footnote@3.0.3?no-dts';
 // @deno-types="./markdownit_plugin.d.ts"
 import { default as MarkdownItTaskLists } from 'https://esm.sh/markdown-it-task-lists@2.1.1?no-dts';
+// @deno-types="./markdownit_plugin.d.ts"
+import { default as MarkdownItTextualUml } from 'https://esm.sh/markdown-it-textual-uml@0.12.0?no-dts';
 
 const __args = parse(Deno.args);
 
@@ -27,7 +29,8 @@ const md = new MarkdownIt('default', {
   }),
 }).use(MarkdownItEmoji)
   .use(MarkdownItFootnote)
-  .use(MarkdownItTaskLists, { enabled: false, label: true });
+  .use(MarkdownItTaskLists, { enabled: false, label: true })
+  .use(MarkdownItTextualUml);
 
 md.renderer.rules.link_open = (tokens, idx, options) => {
   const token = tokens[idx];


### PR DESCRIPTION
First, thank you for the great plugin.

## Rendering Textual UMLs

Added markdwon-it-textual-uml plugin to render textual umls. However, I still have some issues:

- ditaa umls don't get rendered. I have no idea where the issue is, but also didn't investigate.
- mermaid umls also don't get rendered. As explained [here](https://github.com/manastalukdar/markdown-it-textual-uml#additional-steps-for-mermaid) I have to call `mermaid.initialize` after the page gets loaded. However, I have no experince in web development at all and have no idea where I would call that function. Adding 

```html
...
<script type="module">
  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@9/dist/mermaid.esm.min.mjs';
  mermaid.initialize({ startOnLoad: true });
</script>
...
```

to `index.html` doesn't work, so I would appreciate some help.

**Example:**
![textual_uml](https://user-images.githubusercontent.com/50531499/199475653-91a0087e-f01b-4229-8463-b1f4fba93f20.png)
