### PR TITLE
feat: extend filetype configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ require('peek').setup({
                             -- amount of bytes in size
   throttle_time = 'auto',   -- minimum amount of time in milliseconds
                             -- that has to pass before starting new render
+  filetype = { 'markdown' } -- supporting filetypes
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ require('peek').setup({
   app = 'webview',          -- 'webview', 'browser', string or a table of strings
                             -- explained below
 
+  filetype = { 'markdown' } -- list of filetypes to recognize as markdown
+
   -- relevant if update_on_change is true
   throttle_at = 200000,     -- start throttling when file exceeds this
                             -- amount of bytes in size
   throttle_time = 'auto',   -- minimum amount of time in milliseconds
                             -- that has to pass before starting new render
-  filetype = { 'markdown' } -- supporting filetypes
 })
 ```
 

--- a/lua/peek/config.lua
+++ b/lua/peek/config.lua
@@ -64,23 +64,11 @@ function module.setup(incoming)
     syntax = { incoming.syntax, 'boolean', true },
     theme = { incoming.theme, optional(one_of({ 'dark', 'light' })), '"dark" or "light"' },
     update_on_change = { incoming.update_on_change, 'boolean', true },
-    -- TODO: deprecated, should be removed after sometime
-    update_in_insert = { incoming.update_in_insert, 'boolean', true },
     throttle_at = { incoming.throttle_at, 'number', true },
     throttle_time = { incoming.throttle_time, optional(one_of({ 'auto', of_type('number') })), '"auto" or number' },
     app = { incoming.app, optional(one_of({ of_type('string'), every(of_type('string')) })), 'string or string[]' },
-    filetype = { incoming.filetype, 'table' },
+    filetype = { incoming.filetype, optional(every(of_type('string'))), 'string[]' },
   })
-
-  if incoming.update_in_insert ~= nil then
-    vim.api.nvim_notify(
-      'peek.nvim: the config option update_in_insert has been deprecated, use update_on_change instead.',
-      vim.log.levels.WARN,
-      {}
-    )
-    incoming.update_on_change = incoming.update_in_insert
-    incoming.update_in_insert = nil
-  end
 
   config = vim.tbl_extend('force', config, incoming)
 end

--- a/lua/peek/config.lua
+++ b/lua/peek/config.lua
@@ -9,6 +9,7 @@ local config = {
   throttle_at = 200000,
   throttle_time = 'auto',
   app = 'webview',
+  filetype = { 'markdown' },
 }
 
 local function optional(predicate)
@@ -68,6 +69,7 @@ function module.setup(incoming)
     throttle_at = { incoming.throttle_at, 'number', true },
     throttle_time = { incoming.throttle_time, optional(one_of({ 'auto', of_type('number') })), '"auto" or number' },
     app = { incoming.app, optional(one_of({ of_type('string'), every(of_type('string')) })), 'string or string[]' },
+    filetype = { incoming.filetype, 'table' },
   })
 
   if incoming.update_in_insert ~= nil then

--- a/lua/peek/init.lua
+++ b/lua/peek/init.lua
@@ -81,11 +81,12 @@ local function open(bufnr)
 
   if config.get('auto_load') then
     nvim_create_autocmd('BufEnter', {
-      pattern = '*.md',
       group = augroup,
       callback = function(arg)
-        show_throttled:clear()
-        open(arg.buf)
+        if vim.tbl_contains(config.get('filetype'), vim.bo[arg.buf].filetype) then
+          show_throttled:clear()
+          open(arg.buf)
+        end
       end,
     })
   end
@@ -102,14 +103,11 @@ end
 
 module.open = ensure_init(function()
   local bufnr = vim.api.nvim_get_current_buf()
-  local supported_filetypes = config.get('filetype')
+  local filetype = config.get('filetype')
 
-  if not vim.tbl_contains(supported_filetypes, vim.bo[bufnr].filetype) then
-    return vim.api.nvim_notify(
-      'Not a supported filetype: ' .. table.concat(supported_filetypes, ','),
-      vim.log.levels.WARN,
-      {}
-    )
+  if not vim.tbl_contains(filetype, vim.bo[bufnr].filetype) then
+    ---@diagnostic disable-next-line: param-type-mismatch
+    return vim.api.nvim_notify('Not a supported filetype: ' .. table.concat(filetype, ', '), vim.log.levels.WARN, {})
   end
 
   open(bufnr)

--- a/lua/peek/init.lua
+++ b/lua/peek/init.lua
@@ -102,9 +102,14 @@ end
 
 module.open = ensure_init(function()
   local bufnr = vim.api.nvim_get_current_buf()
+  local supported_filetypes = config.get('filetype')
 
-  if vim.bo[bufnr].filetype ~= 'markdown' then
-    return vim.api.nvim_notify('Not a markdown file', vim.log.levels.WARN, {})
+  if not vim.tbl_contains(supported_filetypes, vim.bo[bufnr].filetype) then
+    return vim.api.nvim_notify(
+      'Not a supported filetype: ' .. table.concat(supported_filetypes, ','),
+      vim.log.levels.WARN,
+      {}
+    )
   end
 
   open(bufnr)


### PR DESCRIPTION
Hi, thanks for making this project.

I added a `filetype` configuration so that it can extend to work with various markdown files like `vimwiki`,
since the [vimwiki](https://github.com/vimwiki/vimwiki) plugin will change the default `markdown` filetype to `vimwiki`.

Hope it will be helpful.