### PR TITLE
Fixes webview on macos (and other browsers)

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -16,7 +16,7 @@ logger.info(`DENO_ENV: ${DENO_ENV}`, ...Deno.args);
 
 const listener = Deno.listen({ port: 0 });
 const addr = listener.addr as Deno.NetAddr;
-const serverUrl = `${addr.hostname.replace("0.0.0.0", "localhost")}:${addr.port}` 
+const serverUrl = `${addr.hostname.replace('0.0.0.0', 'localhost')}:${addr.port}`;
 
 logger.info(`listening on ${serverUrl}`);
 
@@ -162,7 +162,7 @@ async function init(socket: WebSocket) {
     }
   })();
 
-  const url = new URL(serverUrl);
+  const url = new URL(`http://${serverUrl}`);
   const searchParams = new URLSearchParams({ theme: __args.theme });
   url.search = searchParams.toString();
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -16,8 +16,9 @@ logger.info(`DENO_ENV: ${DENO_ENV}`, ...Deno.args);
 
 const listener = Deno.listen({ port: 0 });
 const addr = listener.addr as Deno.NetAddr;
+const serverUrl = `${addr.hostname.replace("0.0.0.0", "localhost")}:${addr.port}` 
 
-logger.info(`listening on ${addr.hostname}:${addr.port}`);
+logger.info(`listening on ${serverUrl}`);
 
 async function init(socket: WebSocket) {
   if (DENO_ENV === 'development') {
@@ -89,7 +90,7 @@ async function init(socket: WebSocket) {
         'webview.js',
         `--url=${new URL('index.html', Deno.mainModule).href}`,
         `--theme=${__args['theme']}`,
-        `--serverUrl=${addr.hostname}:${addr.port}`,
+        `--serverUrl=${serverUrl}`,
       ],
       stdin: 'null',
     });
@@ -161,7 +162,7 @@ async function init(socket: WebSocket) {
     }
   })();
 
-  const url = new URL(`http://${addr.hostname}:${addr.port}`);
+  const url = new URL(serverUrl);
   const searchParams = new URLSearchParams({ theme: __args.theme });
   url.search = searchParams.toString();
 


### PR DESCRIPTION
This PR replaces any instance of `0.0.0.0` when referring to the Deno listener and passing through to the webview.

This enables the webview on macos to communicate with the server, whereas before it would fail to connect and hang indefinitely.

This was previously thought to be a bug with webview, and thus I think closes a few rogue issues: #14 & #12, and achieves what #16 set out to do, but fixes the root cause.

For reference, when using the `Deno.listen` function, the docs for the options object have a warning about the hostname on windows, but the same applies to the macos webview.
[See here for souce](https://deno.land/api@v1.31.1?s=Deno.ListenOptions#prop_hostname)
```
    /** A literal IP address or host name that can be resolved to an IP address.
     *
     * __Note about `0.0.0.0`__ While listening `0.0.0.0` works on all platforms,
     * the browsers on Windows don't work with the address `0.0.0.0`.
     * You should show the message like `server running on localhost:8080` instead of
     * `server running on 0.0.0.0:8080` if your program supports Windows.
     *
     * @default {"0.0.0.0"} */
```

And for completeness, here it is working great on macos with the yabai window manager
![image](https://user-images.githubusercontent.com/9119973/221867782-fb1e5e55-212f-47bd-94d4-ae5ed4f77057.png)

 