### PR TITLE
Fixes for Windows

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,5 +1,5 @@
 import { parse } from 'https://deno.land/std@0.159.0/flags/mod.ts';
-import { dirname, join, normalize } from 'https://deno.land/std@0.159.0/path/mod.ts';
+import { dirname, join, normalize, fromFileUrl } from 'https://deno.land/std@0.159.0/path/mod.ts';
 import { open } from 'https://deno.land/x/open@v0.0.5/index.ts';
 import { readChunks } from './read.ts';
 import log from './log.ts';
@@ -75,7 +75,7 @@ async function init(socket: WebSocket) {
 
   if (app === 'webview') {
     const webview = Deno.run({
-      cwd: dirname(new URL(Deno.mainModule).pathname),
+      cwd: dirname(fromFileUrl(Deno.mainModule)),
       cmd: [
         'deno',
         'run',

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,5 +1,5 @@
 import { parse } from 'https://deno.land/std@0.159.0/flags/mod.ts';
-import { dirname, join, normalize, fromFileUrl } from 'https://deno.land/std@0.159.0/path/mod.ts';
+import { dirname, fromFileUrl, join, normalize } from 'https://deno.land/std@0.159.0/path/mod.ts';
 import { open } from 'https://deno.land/x/open@v0.0.5/index.ts';
 import { readChunks } from './read.ts';
 import log from './log.ts';
@@ -173,14 +173,13 @@ async function init(socket: WebSocket) {
     });
 })();
 
-
 const win_signals = ['SIGINT', 'SIGBREAK'] as const;
-const unix_signals = [ 'SIGINT', 'SIGUSR2', 'SIGTERM', 'SIGPIPE', 'SIGHUP' ] as const;
+const unix_signals = ['SIGINT', 'SIGUSR2', 'SIGTERM', 'SIGPIPE', 'SIGHUP'] as const;
 const signals = Deno.build.os === 'windows' ? win_signals : unix_signals;
 
-for (let signal of signals) {
+for (const signal of signals) {
   Deno.addSignalListener(signal, () => {
-    logger.info('SIGNAL: ', signal);
+    logger.info('SIGNAL:', signal);
     Deno.exit();
   });
 }

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -173,15 +173,12 @@ async function init(socket: WebSocket) {
     });
 })();
 
-for (
-  const signal of [
-    'SIGINT',
-    'SIGUSR2',
-    'SIGTERM',
-    'SIGPIPE',
-    'SIGHUP',
-  ] as const
-) {
+
+const win_signals = ['SIGINT', 'SIGBREAK'] as const;
+const unix_signals = [ 'SIGINT', 'SIGUSR2', 'SIGTERM', 'SIGPIPE', 'SIGHUP' ] as const;
+const signals = Deno.build.os === 'windows' ? win_signals : unix_signals;
+
+for (let signal of signals) {
   Deno.addSignalListener(signal, () => {
     logger.info('SIGNAL: ', signal);
     Deno.exit();


### PR DESCRIPTION
Continuation on: https://github.com/toppair/peek.nvim/issues/14 based on @yehuohan's finding.
yehuohan, if you don't mind, can you see if this general path resolution works for you without needing to hard code the vim path?

Notes:
- I have not worked with Typescript before. This works for me but I do not know if it will break on other platforms.
  - Please test/advise. :^) I wonder if the calls can be simplified, or if this is an okay conversion.
- I needed to remove the signals as suggested too https://github.com/toppair/peek.nvim/issues/14#issuecomment-1465417029
  - This part is not included in the PR because I don't know how to branch for OS specific code in Deno, but it should be as easy as using different sets for different operating systems. If you let me know I can push it, or someone else can.
- I am using `lazy.nvim` and using the property `build = 'deno task --quiet build:fast'`, but it does not run automatically. However, I think this is a bug in `lazy.nvim` or my configuration. Running it manually builds okay before and after patch.

Here it is running on my machine before and after the patch is applied: https://www.youtube.com/watch?v=ao0d3cWNn-A