### PR TITLE
feat: package for luarocks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: "release"
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v4
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          template: "rockspec.template"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+# https://github.com/luarocks/luarocks/wiki/Creating-a-Makefile-that-plays-nice-with-LuaRocks
+build: 
+	echo "Do nothing"
+
+install:
+	deno task --quiet build:fast
+	bash -c "mkdir -p $(INST_LUADIR)"
+	cp -r app client lua public $(INST_LUADIR)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 ### :electric_plug: Installation
 
+[![LuaRocks](https://img.shields.io/luarocks/v/toppair/peek.nvim?logo=lua&color=purple)](https://luarocks.org/modules/toppair/peek.nvim)
+
 ```lua
 use({ 'toppair/peek.nvim', run = 'deno task --quiet build:fast' })
 ```

--- a/rockspec.template
+++ b/rockspec.template
@@ -1,0 +1,48 @@
+local git_ref = '$git_ref'
+local modrev = '$modrev'
+local specrev = '-1'
+
+local repo_url = '$repo_url'
+
+rockspec_format = '3.0'
+package = '$package'
+version = modrev .. specrev
+
+description = {
+  summary = '$summary',
+  detailed = [[
+  Features:
+    - live update
+    - synchronized scrolling
+    - github-style look
+    - TeX math
+    - Mermaid diagrams
+  ]],
+  labels = $labels,
+  homepage = '$homepage',
+  $license
+}
+
+dependencies = $dependencies
+
+source = {
+  url = repo_url .. '/archive/' .. git_ref .. '.zip',
+  dir = '$repo_name-' .. '$archive_dir_suffix',
+}
+
+if modrev == 'scm' then
+   source = {
+      url = 'git://github.com/toppair/$repo_name',
+   }
+end
+
+build = {
+   type = 'make',
+   install_variables = {
+     INST_PREFIX='$(PREFIX)',
+     INST_BINDIR='$(BINDIR)',
+     INST_LIBDIR='$(LIBDIR)',
+     INST_LUADIR='$(LUADIR)',
+     INST_CONFDIR='$(CONFDIR)',
+  },
+}

--- a/scripts/luarocks_install.sh
+++ b/scripts/luarocks_install.sh
@@ -1,0 +1,5 @@
+#/usr/bin/env bash
+
+deno task --quiet build:fast
+mkdir -p $(INST_LUADIR)
+cp -r app client lua public $(INST_LUADIR)


### PR DESCRIPTION
### Summary

This PR is part of a push to get Neovim plugins on LuaRocks.

* See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) by @teto.

### Things done:

* Add a workflow that publishes tags to LuaRocks.
* Add a LuaRocks badge to the readme (assuming the existence of a `toppair/peek.nvim` package).

### Notes

* For the release workflow to work, someone with a Luarocks account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
* Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` label has to be added manually, for this plugin to show up in https://luarocks.org/labels/neovim
* If you would prefer rolling releases without tags, [this is also possible](https://github.com/nvim-neorocks/luarocks-tag-release#version-optional).

__Adding the API key (screen shot)__
![github-add-luarocks-api-key](https://user-images.githubusercontent.com/12857160/211071297-afb129be-7a8f-4662-b282-9d52bb0286de.png)