### PR TITLE
fix(mermaid): prevent frontmatter in mermaid blocks from breaking compilation

### DIFF
--- a/app/src/markdownit.ts
+++ b/app/src/markdownit.ts
@@ -100,7 +100,7 @@ md.renderer.rules.fence = (() => {
   const fence = md.renderer.rules.fence!;
   const escapeHtml = md.utils.escapeHtml;
   const regex = new RegExp(
-    /^(flowchart|sequenceDiagram|gantt|classDiagram|stateDiagram|pie|journey|C4Context|erDiagram|requirementDiagram|gitGraph)/,
+    /^(?<frontmatter>---[\s\S]+---)?\s*(?<content>(?<charttype>flowchart|sequenceDiagram|gantt|classDiagram|stateDiagram|pie|journey|C4Context|erDiagram|requirementDiagram|gitGraph)[\s\S]+)/
   );
 
   return (tokens, idx, options, env, self) => {
@@ -108,6 +108,7 @@ md.renderer.rules.fence = (() => {
     const content = token.content.trim();
 
     if (regex.test(content)) {
+      const match = regex.exec(content);
       return `
         <div
           class="mermaid"
@@ -116,7 +117,7 @@ md.renderer.rules.fence = (() => {
           <div
             id="graph-mermaid-${env.genId(hashCode(content))}"
             data-graph="mermaid"
-            data-graph-definition="${escapeHtml(content)}"
+            data-graph-definition="${escapeHtml(match?.groups?.content || '')}"
           >
             <div class="loader"></div>
           </div>


### PR DESCRIPTION
According to the [mermaidjs docs](https://mermaid.js.org/syntax/flowchart.html#a-node-with-text) it is possible to have [frontmatter](https://frontmatter.codes/docs/markdown) at the front of the diagrams to provide additional metadata.

Ideally, this should be fed to the mermaidjs code, however this is meant to not break things if the frontmatter code is there, and eventually push it to mermaidjs code.