### PR TITLE
fix: markdown-it punycode + use v12.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public/*
 !public/style.css
 .luarc.json
 peek.log
+deno.lock

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### :battery: Requirements
 
-- [Deno](https://deno.land) v1.25.0+
+- [Deno](https://deno.land)
 
 ### :electric_plug: Installation
 

--- a/app/src/markdownit.ts
+++ b/app/src/markdownit.ts
@@ -2,7 +2,7 @@ import { hashCode, uniqueIdGen } from './util.ts';
 import { parse } from 'https://deno.land/std@0.159.0/flags/mod.ts';
 import { default as highlight } from 'https://cdn.skypack.dev/highlight.js@11.6.0';
 // @deno-types="https://cdn.skypack.dev/@types/markdown-it@12.2.3?dts"
-import MarkdownIt from 'https://esm.sh/markdown-it@13.0.1?no-dts';
+import MarkdownIt from 'https://esm.sh/markdown-it@12.3.2';
 // @deno-types="./markdownit_plugin.d.ts"
 import { default as MarkdownItEmoji } from 'https://esm.sh/markdown-it-emoji@2.0.2?no-dts';
 // @deno-types="./markdownit_plugin.d.ts"

--- a/app/src/markdownit.ts
+++ b/app/src/markdownit.ts
@@ -1,17 +1,13 @@
 import { hashCode, uniqueIdGen } from './util.ts';
 import { parse } from 'https://deno.land/std@0.159.0/flags/mod.ts';
 import { default as highlight } from 'https://cdn.skypack.dev/highlight.js@11.6.0';
-// @deno-types="https://cdn.skypack.dev/@types/markdown-it@12.2.3?dts"
-import MarkdownIt from 'https://esm.sh/markdown-it@12.3.2';
-// @deno-types="./markdownit_plugin.d.ts"
-import { default as MarkdownItEmoji } from 'https://esm.sh/markdown-it-emoji@2.0.2?no-dts';
-// @deno-types="./markdownit_plugin.d.ts"
-import { default as MarkdownItFootnote } from 'https://esm.sh/markdown-it-footnote@3.0.3?no-dts';
-// @deno-types="./markdownit_plugin.d.ts"
-import { default as MarkdownItTaskLists } from 'https://esm.sh/markdown-it-task-lists@2.1.1?no-dts';
-// @deno-types="./markdownit_plugin.d.ts"
-import { default as MarkdownItTexmath } from 'https://esm.sh/markdown-it-texmath@1.0.0?no-dts';
-import Katex from 'https://esm.sh/katex@0.16.3?no-dts';
+// @deno-types="https://esm.sh/v133/@types/markdown-it@13.0.5/index.d.ts";
+import MarkdownIt from 'https://esm.sh/markdown-it@13.0.2';
+import { default as MarkdownItEmoji } from 'https://esm.sh/markdown-it-emoji@2.0.2';
+import { default as MarkdownItFootnote } from 'https://esm.sh/markdown-it-footnote@3.0.3';
+import { default as MarkdownItTaskLists } from 'https://esm.sh/markdown-it-task-lists@2.1.1';
+import { default as MarkdownItTexmath } from 'https://esm.sh/markdown-it-texmath@1.0.0';
+import Katex from 'https://esm.sh/katex@0.16.3';
 
 const __args = parse(Deno.args);
 

--- a/app/src/markdownit_plugin.d.ts
+++ b/app/src/markdownit_plugin.d.ts
@@ -1,7 +1,0 @@
-import {
-  PluginSimple,
-  PluginWithOptions,
-} from 'https://cdn.skypack.dev/@types/markdown-it@12.2.3?dts';
-
-declare const plugin: PluginSimple | PluginWithOptions<Record<string, unknown>>;
-export = plugin;

--- a/deno.json
+++ b/deno.json
@@ -11,6 +11,9 @@
   "compilerOptions": {
     "lib": ["dom", "deno.ns", "deno.unstable"]
   },
+  "imports": {
+    "node:punycode": "https://deno.land/x/punycode/punycode.js"
+  },
   "fmt": {
     "options": {
       "useTabs": false,


### PR DESCRIPTION
Fixes #47

Using the following the error with punycode is fixed
```JSON
"node:punycode": "https://deno.land/x/punycode/punycode.js"
```

It looks like 12.3.2 is the latest working version for peek.nvim.
```JAVASCRIPT
import MarkdownIt from 'https://esm.sh/markdown-it@12.3.2';
```

If anyone is interested in using the plugin without waiting for the pull request, you can go ahead and change the 4 lines of code and you should be good to go. 
