### PR TITLE
Fix texmath delimiters orders

### DIFF
--- a/app/src/markdownit.ts
+++ b/app/src/markdownit.ts
@@ -32,7 +32,7 @@ const md = new MarkdownIt('default', {
   .use(MarkdownItTaskLists, { enabled: false, label: true })
   .use(MarkdownItTexmath, {
     engine: Katex,
-    delimiters: ['dollars', 'gitlab'],
+    delimiters: ['gitlab', 'dollars'],
     katexOptions: { macros: { '\\R': '\\mathbb{R}' } },
   });
 


### PR DESCRIPTION
Since [delimiters setting](https://github.com/goessner/markdown-it-texmath#features) `gitlab` using ``$`...`$`` as inline, and `dollars` using `$...$` as inline. If we put `dollars` before `gitlab`, it will override `gitlab` settings, and made ``$`...`$`` render extra `'` in math.