### PR TITLE
feat: add zoom functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,17 +90,19 @@ vim.api.nvim_create_user_command('PeekClose', require('peek').close, {})
 
 The following keybinds are active when preview window is focused:
 
-| key ||
-|-|-|
-| k | scroll up               |
-| j | scroll down             |
-| u | scroll up half a page   |
-| d | scroll down half a page |
-| g | scroll to top           |
-| G | scroll to bottom        |
-| + | zoom in by 10%          |
-| - | zoom out by 10%         |
-| * | zoom reset to 100%      |
+| key |                         |
+| --- | ----------------------- |
+| k   | scroll up               |
+| j   | scroll down             |
+| l   | scroll left             |
+| h   | scroll right            |
+| u   | scroll up half a page   |
+| d   | scroll down half a page |
+| g   | scroll to top           |
+| G   | scroll to bottom        |
+| +   | zoom in by 10%          |
+| -   | zoom out by 10%         |
+| \*  | zoom reset to 100%      |
 
 ### :mag: Preview window
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ The following keybinds are active when preview window is focused:
 | d | scroll down half a page |
 | g | scroll to top           |
 | G | scroll to bottom        |
+| + | zoom in by 10%          |
+| - | zoom out by 10%         |
+| * | zoom reset to 100%      |
 
 ### :mag: Preview window
 

--- a/README.md
+++ b/README.md
@@ -90,19 +90,14 @@ vim.api.nvim_create_user_command('PeekClose', require('peek').close, {})
 
 The following keybinds are active when preview window is focused:
 
-| key |                         |
-| --- | ----------------------- |
-| k   | scroll up               |
-| j   | scroll down             |
-| l   | scroll right            |
-| h   | scroll left             |
-| u   | scroll up half a page   |
-| d   | scroll down half a page |
-| g   | scroll to top           |
-| G   | scroll to bottom        |
-| +   | zoom in by 10%          |
-| -   | zoom out by 10%         |
-| \*  | zoom reset to 100%      |
+| key ||
+|-|-|
+| k | scroll up               |
+| j | scroll down             |
+| u | scroll up half a page   |
+| d | scroll down half a page |
+| g | scroll to top           |
+| G | scroll to bottom        |
 
 ### :mag: Preview window
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ The following keybinds are active when preview window is focused:
 | --- | ----------------------- |
 | k   | scroll up               |
 | j   | scroll down             |
-| l   | scroll left             |
-| h   | scroll right            |
+| l   | scroll right            |
+| h   | scroll left             |
 | u   | scroll up half a page   |
 | d   | scroll down half a page |
 | g   | scroll to top           |

--- a/app/src/markdownit.ts
+++ b/app/src/markdownit.ts
@@ -111,7 +111,7 @@ md.renderer.rules.fence = (() => {
       const match = regex.exec(content);
       return `
         <div
-          class="mermaid"
+          class="peek-mermaid-container"
           data-line-begin="${token.attrGet('data-line-begin')}"
         >
           <div
@@ -119,7 +119,7 @@ md.renderer.rules.fence = (() => {
             data-graph="mermaid"
             data-graph-definition="${escapeHtml(match?.groups?.content || '')}"
           >
-            <div class="loader"></div>
+            <div class="peek-loader"></div>
           </div>
         </div>
       `;

--- a/client/src/mermaid.ts
+++ b/client/src/mermaid.ts
@@ -9,6 +9,9 @@ function init() {
   mermaid.initialize({
     startOnLoad: false,
     theme: peek?.theme === 'light' ? 'neutral' : 'dark',
+    flowchart: {
+      htmlLabels: false,
+    },
   });
 }
 

--- a/client/src/script.ts
+++ b/client/src/script.ts
@@ -56,7 +56,7 @@ const zoom = {
     this.update();
   },
   reset() {
-    this.level = 1; 
+    this.level = 1;
     this.update();
   },
   update() {

--- a/client/src/script.ts
+++ b/client/src/script.ts
@@ -32,7 +32,7 @@ function setKeybinds() {
         window.scrollTo({ top: 0 });
         break;
       case 'G':
-        window.scrollTo({ top: document.body.scrollHeight });
+        window.scrollTo({ top: document.body.scrollHeight * zoom.level });
         break;
       case '+':
         zoom.up();

--- a/client/src/script.ts
+++ b/client/src/script.ts
@@ -16,6 +16,12 @@ function setKeybinds() {
       case 'k':
         window.scrollBy({ top: -50 });
         break;
+      case 'l':
+        window.scrollBy({ left: 50 });
+        break;
+      case 'h':
+        window.scrollBy({ left: -50 });
+        break;
       case 'd':
         window.scrollBy({ top: window.innerHeight / 2 });
         break;

--- a/client/src/script.ts
+++ b/client/src/script.ts
@@ -247,8 +247,8 @@ addEventListener('DOMContentLoaded', () => {
       const target = block[0];
       const next = target ? block[1] : blocks[0][0];
 
-      const offsetBegin = target ? getOffset(target) : 0;
-      const offsetEnd = next ? getOffset(next) : markdownBody.scrollHeight;
+      const offsetBegin = (target ? getOffset(target) : 0) * zoom.level;
+      const offsetEnd = (next ? getOffset(next) : markdownBody.scrollHeight) * zoom.level;
 
       const lineBegin = target ? Number(target.dataset.lineBegin) : 1;
       const lineEnd = next ? Number(next.dataset.lineBegin) : source.lcount + 1;

--- a/client/src/script.ts
+++ b/client/src/script.ts
@@ -28,9 +28,47 @@ function setKeybinds() {
       case 'G':
         window.scrollTo({ top: document.body.scrollHeight });
         break;
+      case '+':
+        zoom.up();
+        break;
+      case '-':
+        zoom.down();
+        break;
+      case '*':
+        zoom.reset();
+        break;
     }
   });
 }
+
+const zoom = {
+  level: 1,
+  zoomMin: 0.5,
+  zoomMax: 2.5,
+  zoomStep: 0.1,
+  zoomLabel: document.getElementById('zoom-level') as HTMLDivElement,
+  up() {
+    this.level = Math.min(this.level + this.zoomStep, this.zoomMax);
+    this.update();
+  },
+  down() {
+    this.level = Math.max(this.level - this.zoomStep, this.zoomMin);
+    this.update();
+  },
+  reset() {
+    this.level = 1; 
+    this.update();
+  },
+  update() {
+    document.body.style.setProperty('zoom', this.level.toString());
+    this.zoomLabel.textContent = `${(this.level * 100).toFixed(0)}%`;
+    this.zoomLabel.style.setProperty('zoom', (1 / this.level).toString());
+    if (this.zoomLabel.style.visibility === 'hidden') {
+      this.zoomLabel.style.visibility = 'visible';
+      setTimeout(() => (this.zoomLabel.style.visibility = 'hidden'), 1000);
+    }
+  },
+};
 
 addEventListener('DOMContentLoaded', () => {
   const markdownBody = document.getElementById('markdown-body') as HTMLDivElement;

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -13,12 +13,13 @@ export function findLast<T>(array: Array<T> | undefined, predicate: (item: T) =>
 interface Config {
   theme?: string;
   serverUrl?: string;
+  ctx?: string;
 }
 
 export function getInjectConfig(): Config {
   const peek = Reflect.get(window, 'peek');
 
-  if (peek) return peek;
+  if (peek) return { ctx: 'webview', ...peek };
 
   const params: Config = {};
 
@@ -27,6 +28,7 @@ export function getInjectConfig(): Config {
   });
 
   params.serverUrl = params.serverUrl || location.host;
+  params.ctx = 'browser';
 
   return params;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
 
   <body data-theme="dark" >
     <base id="base" />
+    <div id="zoom-level" style='visibility: hidden;'></div>
     <main id="markdown-body" class="markdown-body">
       <div class="loader"></div>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -1,22 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>Peek preview</title>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link href="github-markdown.min.css" rel="stylesheet" />
-    <link href="katex.min.css" rel="stylesheet" />
-    <link href="style.css" rel="stylesheet" />
-  </head>
 
-  <body data-theme="dark" >
-    <base id="base" />
-    <div id="zoom-level" style='visibility: hidden;'></div>
-    <main id="markdown-body" class="markdown-body">
-      <div class="loader"></div>
-    </main>
-    <div class="marker"></div>
-    <script src="mermaid.min.js"></script>
-    <script src="script.bundle.js"></script>
-  </body>
+<head>
+  <title>Peek preview</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="github-markdown.min.css" rel="stylesheet" />
+  <link href="katex.min.css" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
+</head>
+
+<body data-theme="dark">
+  <base id="base" />
+  <div id="zoom-level" style='visibility: hidden;'></div>
+  <main id="markdown-body" class="markdown-body">
+    <div class="loader"></div>
+  </main>
+  <div class="marker"></div>
+  <script src="mermaid.min.js"></script>
+  <script src="script.bundle.js"></script>
+</body>
+
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -10,13 +10,13 @@
   <link href="style.css" rel="stylesheet" />
 </head>
 
-<body data-theme="dark">
-  <base id="base" />
-  <div id="zoom-level" style='visibility: hidden;'></div>
-  <main id="markdown-body" class="markdown-body">
-    <div class="loader"></div>
+<body class="peek-body" data-theme="dark">
+  <base id="peek-base" />
+  <main id="peek-markdown-body" class="markdown-body">
+    <div class="peek-loader"></div>
   </main>
-  <div class="marker"></div>
+  <div class="peek-marker"></div>
+  <div id="peek-zoom-label"></div>
   <script src="mermaid.min.js"></script>
   <script src="script.bundle.js"></script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -73,7 +73,14 @@ div.mermaid {
   overflow: auto;
   line-height: 1.45;
   font-size: 85%;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    Liberation Mono,
+    monospace;
   word-wrap: normal;
   background-color: var(--color-canvas-subtle);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1,10 +1,6 @@
 html {
   background: #333;
 }
-body {
-  margin: 0;
-  padding: 0;
-}
 body::-webkit-scrollbar {
   width: 4px;
 }
@@ -14,6 +10,10 @@ body::-webkit-scrollbar-track {
 body::-webkit-scrollbar-thumb {
   background-color: #555;
 }
+.peek-body {
+  margin: 0;
+  padding: 0;
+}
 .markdown-body {
   box-sizing: border-box;
   min-width: 200px;
@@ -21,6 +21,7 @@ body::-webkit-scrollbar-thumb {
   margin: 0 auto;
   padding: 45px;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 @media (max-width: 767px) {
   .markdown-body {
@@ -35,7 +36,7 @@ body::-webkit-scrollbar-thumb {
     scale: 1;
   }
 }
-.loader {
+.peek-loader {
   position: absolute;
   display: flex;
   width: 40px;
@@ -44,8 +45,8 @@ body::-webkit-scrollbar-thumb {
   justify-content: space-between;
   translate: -50% -50%;
 }
-.loader::before,
-.loader::after {
+.peek-loader::before,
+.peek-loader::after {
   content: '';
   width: 10px;
   height: 10px;
@@ -53,10 +54,10 @@ body::-webkit-scrollbar-thumb {
   background-color: blue;
   animation: 0.5s linear infinite alternate pulse;
 }
-.loader::after {
+.peek-loader::after {
   animation-direction: alternate-reverse;
 }
-.marker {
+.peek-marker {
   position: fixed;
   width: 4px;
   height: 4px;
@@ -65,7 +66,7 @@ body::-webkit-scrollbar-thumb {
   border-radius: 50%;
   background-color: blue;
 }
-div.mermaid {
+.peek-mermaid-container {
   margin-top: 0;
   margin-bottom: 16px;
   padding: 16px;
@@ -84,13 +85,28 @@ div.mermaid {
   word-wrap: normal;
   background-color: var(--color-canvas-subtle);
 }
-div.mermaid:has(svg) {
+.peek-mermaid-container:has(svg) {
   height: auto !important;
 }
-div[data-graph='mermaid']:has(> .loader) {
+div[data-graph='mermaid']:has(> .peek-loader) {
   position: relative;
   height: 100%;
   min-height: 50px;
+}
+#peek-zoom-label {
+  position: fixed;
+  top: 30px;
+  right: 30px;
+  padding: 10px;
+  opacity: 0;
+  border-radius: 8px;
+  background-color: rgba(100, 100, 100, 0.7);
+  color: #fff;
+  text-shadow: 1px 1px 2px #000;
+  font-family: Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  z-index: 9999;
 }
 .hljs-doctag,
 .hljs-keyword,
@@ -168,16 +184,4 @@ div[data-graph='mermaid']:has(> .loader) {
 .hljs-deletion {
   color: var(--color-prettylights-syntax-markup-deleted-text);
   background-color: var(--color-prettylights-syntax-markup-deleted-bg);
-}
-#zoom-level {
-  position: fixed;
-  top: 30px;
-  right: 30px;
-  padding: 10px;
-  border-radius: 8px;
-  background-color: rgba(150, 150, 150, 0.7);
-  color: #fff;
-  font-family: Arial, sans-serif;
-  font-size: 14px;
-  z-index: 9999;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -162,3 +162,15 @@ div[data-graph='mermaid']:has(> .loader) {
   color: var(--color-prettylights-syntax-markup-deleted-text);
   background-color: var(--color-prettylights-syntax-markup-deleted-bg);
 }
+#zoom-level {
+  position: fixed;
+  top: 30px;
+  right: 30px;
+  padding: 10px;
+  border-radius: 8px;
+  background-color: rgba(150, 150, 150, 0.7);
+  color: #fff;
+  font-family: Arial, sans-serif;
+  font-size: 14px;
+  z-index: 9999;
+}


### PR DESCRIPTION
Adds zoom functionality by means of the css `zoom` property. It's probably not ideal as `zoom` is non-standard, but it works fine in my system. I tried using `transform: scale()` as is recommended, but that leaves content outside of the visible window area so it didn't really work.
The zoom is bound to `+`, `-` and `*` for zoom up, down and reset to 100% respectively.
I added it for use in webview, but is also active when using the browser option. This may be undesired (although it seems to work fine there too, at least in brave).