### PR TITLE
fix: mermaid simple `graph`

### DIFF
--- a/app/src/markdownit.ts
+++ b/app/src/markdownit.ts
@@ -100,7 +100,7 @@ md.renderer.rules.fence = (() => {
   const fence = md.renderer.rules.fence!;
   const escapeHtml = md.utils.escapeHtml;
   const regex = new RegExp(
-    /^(?<frontmatter>---[\s\S]+---)?\s*(?<content>(?<charttype>flowchart|sequenceDiagram|gantt|classDiagram|stateDiagram|pie|journey|C4Context|erDiagram|requirementDiagram|gitGraph)[\s\S]+)/,
+    /^(?<frontmatter>---[\s\S]+---)?\s*(?<content>(?<charttype>flowchart|sequenceDiagram|gantt|classDiagram|stateDiagram|pie|journey|C4Context|erDiagram|requirementDiagram|gitGraph|graph)[\s\S]+)/,
   );
 
   return (tokens, idx, options, env, self) => {


### PR DESCRIPTION
Mermaid rendering is broken for just `graph`

```mermaid
graph
  A --> B
```
is broken, where

```mermaid
flowchart
  A --> B
```
is working