### PR TITLE
feat: Add insecure build option for ignoring HTTPS certs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
     "build": "deno run --allow-run --allow-net --allow-read --allow-write --allow-env --no-check scripts/build.js",
+    "build:insecure": "deno run --allow-run --allow-net --allow-read --allow-write --allow-env --no-check --unsafely-ignore-certificate-errors scripts/build.js",
     "build:watch": "deno task build --watch",
     "build:fast": "FAST=true deno task --quiet build",
     "build:debug": "DEBUG=true deno task build",


### PR DESCRIPTION
This PR adds a new build option for `peek` to support being able to skip checking HTTPS certificate errors to support deployment situations where corporate security software is "middleman-ing" HTTPS traffic and resulting in failed builds using the pre-existing configurations.

Before:
![image](https://github.com/user-attachments/assets/574a5791-3922-4049-a40e-9f9e27c709e0)

After:
![image](https://github.com/user-attachments/assets/8540c759-9ba6-46c1-932c-8555d3f3e90b)
