### PR TITLE
feat: allow the color scheme to based on os color scheme, and allow changing color scheme on open

### DIFF
--- a/lua/peek/app.lua
+++ b/lua/peek/app.lua
@@ -32,7 +32,7 @@ function module.setup(cfg)
   local theme = cfg['theme'] or config.get('theme')
 
   if cfg['auto_os_theme'] or config.get('auto_os_theme') then
-    theme = util.get_theme()
+    theme = util.get_color_scheme()
   end
 
   local args = {

--- a/lua/peek/app.lua
+++ b/lua/peek/app.lua
@@ -1,4 +1,5 @@
 local config = require('peek.config')
+local util = require('peek.util')
 
 local chansend = vim.fn.chansend
 local concat = table.concat
@@ -27,9 +28,15 @@ end
 
 function module.setup()
   local sep = vim.loop.os_uname().sysname:match('Windows') and '\\' or '/'
+  local theme = config.get('theme')
+
+  if config.get('auto_os_theme') then
+    theme = util.get_theme()
+  end
+
   local args = {
     '--logfile=' .. string.format('%s%speek.log', vim.fn.stdpath('log'), sep),
-    '--theme=' .. config.get('theme'),
+    '--theme=' .. theme,
     '--app=' .. vim.json.encode(config.get('app')),
   }
 

--- a/lua/peek/app.lua
+++ b/lua/peek/app.lua
@@ -26,11 +26,12 @@ local function message(chunks)
   end, chunks))
 end
 
-function module.setup()
+function module.setup(cfg)
+  local cfg = cfg or {}
   local sep = vim.loop.os_uname().sysname:match('Windows') and '\\' or '/'
-  local theme = config.get('theme')
+  local theme = cfg['theme'] or config.get('theme')
 
-  if config.get('auto_os_theme') then
+  if cfg['auto_os_theme'] or config.get('auto_os_theme') then
     theme = util.get_theme()
   end
 

--- a/lua/peek/config.lua
+++ b/lua/peek/config.lua
@@ -5,6 +5,7 @@ local config = {
   close_on_bdelete = true,
   syntax = true,
   theme = 'dark',
+  auto_os_theme = false,
   update_on_change = true,
   throttle_at = 200000,
   throttle_time = 'auto',

--- a/lua/peek/init.lua
+++ b/lua/peek/init.lua
@@ -17,7 +17,8 @@ local function get_buf_content(bufnr)
   return concat(nvim_buf_get_lines(bufnr, 0, -1, false), '\n'):gsub('%s*$', '')
 end
 
-local function open(bufnr)
+local function open(bufnr, cfg)
+  app.setup(cfg)
   augroup = nvim_create_augroup('PeekActiveAugroup', { clear = true })
 
   app.init(function()

--- a/lua/peek/util.lua
+++ b/lua/peek/util.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+local function get_color_scheme()
+  local color_scheme = 'light'
+  local system = vim.loop.os_uname().sysname
+  if system == 'Darwin' then
+    if vim.fn.executable('defaults') ~= 0 then
+      local appleInterfaceStyle = vim.fn.system({ 'defaults', 'read', '-g', 'AppleInterfaceStyle' })
+      if appleInterfaceStyle:find('Dark') then
+        color_scheme = 'dark'
+      end
+    end
+  end
+
+  return color_scheme
+end
+
+M.get_color_scheme = get_color_scheme
+return M


### PR DESCRIPTION
Allows me to do this in config

```lua
return {
    "praveenperera/peek.nvim",
    event = { "VeryLazy" },
    build = "deno task --quiet build:fast",
    config = function()
        require("peek").setup({
            theme = "light",
            auto_os_theme = true,
        })
        vim.api.nvim_create_user_command("PeekOpen", require("peek").open, {})
        vim.api.nvim_create_user_command("PeekOpenDark", function(bufnr)
            require("peek").open(
                bufnr,
                { theme = "dark", auto_os_theme = false }
            )
        end, {})
        vim.api.nvim_create_user_command("PeekOpenLight", function(bufnr)
            require("peek").open(
                bufnr,
                { theme = "light", auto_os_theme = false }
            )
        end, {})
        vim.api.nvim_create_user_command("PeekClose", require("peek").close, {})
    end,
}
```