### PR TITLE
feat: render Github alert blocks

### DIFF
--- a/app/src/markdownit.ts
+++ b/app/src/markdownit.ts
@@ -7,6 +7,7 @@ import { full as MarkdownItEmoji } from 'https://esm.sh/markdown-it-emoji@3.0.0'
 import { default as MarkdownItFootnote } from 'https://esm.sh/markdown-it-footnote@4.0.0';
 import { default as MarkdownItTaskLists } from 'https://esm.sh/markdown-it-task-lists@2.1.1';
 import { default as MarkdownItTexmath } from 'https://esm.sh/markdown-it-texmath@1.0.0';
+import { default as MarkdownItGitHubAlerts } from 'https://esm.sh/markdown-it-github-alerts@1.0.0';
 import Katex from 'https://esm.sh/katex@0.16.9';
 
 const __args = parseArgs(Deno.args);
@@ -38,7 +39,8 @@ const md = new MarkdownIt('default', {
       strict: false,
       throwOnError: false,
     },
-  });
+  })
+  .use(MarkdownItGitHubAlerts);
 
 md.renderer.rules.link_open = (tokens, idx, options) => {
   const token = tokens[idx];

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -57,7 +57,7 @@ const result = await Promise.allSettled([
   emit('client/src/script.ts', 'public/script.bundle.js'),
 
   download(
-    'https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.5.1/github-markdown.min.css',
+    'https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown.min.css',
     'public/github-markdown.min.css',
     (uint8array) => {
       return new TextEncoder().encode(


### PR DESCRIPTION
I added the [markdown-it-github-alerts](https://github.com/antfu/markdown-it-github-alerts) plugin to the `markdownit.ts` to render [Github alert blocks](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).

The alerts were not rendering correctly at first: the border of the alert and the title were slightly overlapping and proper spacing wasn't respected.
Updating the [github-markdown css file](https://github.com/sindresorhus/github-markdown-css) in `build.js` to version 5.8.1 appears to have solved the issue.

Hopefully this gets merge, I use it all the time 😄 