### PR TITLE
Fix: Update mermaid to 11.12.0

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -69,7 +69,7 @@ const result = await Promise.allSettled([
   ),
 
   download(
-    'https://cdn.jsdelivr.net/npm/mermaid@10.9.0/dist/mermaid.min.js',
+    'https://cdn.jsdelivr.net/npm/mermaid@11.12.0/dist/mermaid.min.js',
     'public/mermaid.min.js',
   ),
 


### PR DESCRIPTION
Update supported mermaid version to 11.12.0.

Addresses #83

This is the same version currently deployed in GitHub as seen when doing:
````
```mermaid
info
```
````

```mermaid
info
```